### PR TITLE
issue 229

### DIFF
--- a/react_ui/components/BackButton/index.js
+++ b/react_ui/components/BackButton/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
-import { Link, browserHistory, withRouter } from 'react-router';
+import { withRouter } from 'react-router';
 
 class BackButton extends React.Component {
   constructor(props) {

--- a/react_ui/components/BackButton/index.js
+++ b/react_ui/components/BackButton/index.js
@@ -44,7 +44,6 @@ class BackButton extends React.Component {
 }
 
 BackButton.propTypes = {
-  //router: PropTypes.object,
   history: PropTypes.object,
 };
 

--- a/react_ui/components/BackButton/index.js
+++ b/react_ui/components/BackButton/index.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
+import { Link, browserHistory, withRouter } from 'react-router';
 
 class BackButton extends React.Component {
   constructor(props) {
@@ -9,7 +10,7 @@ class BackButton extends React.Component {
   }
 
   handleClick() {
-    this.context.history.goBack();
+    this.props.history.goBack();
   }
 
   render() {
@@ -42,8 +43,9 @@ class BackButton extends React.Component {
   }
 }
 
-BackButton.contextTypes = {
+BackButton.propTypes = {
+  //router: PropTypes.object,
   history: PropTypes.object,
 };
 
-export default connect()(BackButton);
+export default withRouter(connect()(BackButton));

--- a/react_ui/components/ProjectMenu/index.js
+++ b/react_ui/components/ProjectMenu/index.js
@@ -18,7 +18,7 @@ class ProjectMenu extends Component {
   }
 
   render(props) {
-    if (this.props.protocol.items){
+    if (this.props.protocol.items && this.props.protocol.items.length){
       return (
       <div className="card">
         <p>Welcome Back</p>


### PR DESCRIPTION
- use `this.props.history.goBack()` instead of `this.context.history.goBack()` because context.history was giving `Uncaught TypeError: Cannot read property 'goBack' of undefined` error
- in project menu, added logic so that only when `this.props.protocol.items.length > 0` does the map function run because the map function was giving `this props.protocol.items.map is not a function` error